### PR TITLE
fix(worker): fix breaking script when checking ORIGIN_HOSTNAME

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -39,7 +39,7 @@ const handleRequest = async (request, env, ctx) => {
   }
 
   url.hostname = env.ORIGIN_HOSTNAME;
-  if (!url.match(/^https:\/\/main--.*--.*\.(?:aem|hlx)\.live/)) {
+  if (!url.origin.match(/^https:\/\/main--.*--.*\.(?:aem|hlx)\.live/)) {
     return new Response('Invalid ORIGIN_HOSTNAME', { status: 500 });
   }
   const req = new Request(url, request);


### PR DESCRIPTION
## Description

The last change to make sure that `ORIGIN_HOSTNAME` is well-formatted actually breaks the worker.

```
[wrangler:err] TypeError: url.match is not a function
    at Object.handleRequest [as fetch] (file:///src/index.mjs:40:12)
    at fetchDispatcher (file:///.wrangler/tmp/bundle-rIuIXO/middleware-loader.entry.ts:56:17)
```

In the script, `url` is an `Url` type and not a string. A property of `url` should be checked instead.

## Related Issue
https://github.com/adobe/helix-cloudflare-prod-worker-template/issues/6

## Motivation and Context
Fixes a bug.

## How Has This Been Tested?
Checked with local tests (`wrangler dev`) and on published workers.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
